### PR TITLE
Login create links

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -25,7 +25,7 @@ function App() {
             </div>
           </div>
         </div> 
-        } />
+      } />
     </div>
   );
 }

--- a/src/Components/CreateAccount/CreateAccount.js
+++ b/src/Components/CreateAccount/CreateAccount.js
@@ -21,10 +21,10 @@ const CreateAccount = () => {
   }
 
   return(
-    <main>
+    <main className="form_body">
       <img src={banner} alt="Tripedia for all your travel planning needs" className="banner" />
       <form className="create_account_form">
-        <h2>Create Account</h2>
+        <h2 className="form_title">Create Account</h2>
         <input
           type="text"
           className="name_input"

--- a/src/Components/CreateAccount/CreateAccount.js
+++ b/src/Components/CreateAccount/CreateAccount.js
@@ -56,11 +56,13 @@ const CreateAccount = () => {
           value={confirmPassword}
           onChange={handleChange}>
         </input>
-        <button
-          disabled={!isEnabled}
-          className="submit_button"
-          type="submit">Submit
-        </button>
+        <NavLink to="/" className="button">
+          <button
+            disabled={!isEnabled}
+            className="submit_button"
+            type="submit">Submit
+          </button>
+        </NavLink>
         <NavLink to="/login">
           <p className="login_link">Login</p>
         </NavLink>

--- a/src/Components/CreateAccount/CreateAccount.js
+++ b/src/Components/CreateAccount/CreateAccount.js
@@ -1,13 +1,10 @@
 import React, { useState } from 'react';
+import { NavLink } from 'react-router-dom';
 import './CreateAccount.scss';
 import banner from '../../images/banner.jpg'
 
 
 const CreateAccount = () => {
-  // const [nameInput, handleName] = useState('');
-  // const [emailInput, handleEmail] = useState('');
-  // const [passwordInput, handlePassword] = useState('');
-  // const [confirmPasswordInput, handlePasswordConfirmation] = useState('');
   
   const [accountState, setAccountState] = useState({
     name: '',
@@ -64,6 +61,9 @@ const CreateAccount = () => {
           className="submit_button"
           type="submit">Submit
         </button>
+        <NavLink to="/login">
+          <p className="login_link">Login</p>
+        </NavLink>
       </form>
     </main>
   )

--- a/src/Components/CreateAccount/CreateAccount.js
+++ b/src/Components/CreateAccount/CreateAccount.js
@@ -22,7 +22,7 @@ const CreateAccount = () => {
 
   return(
     <main>
-      <img src={banner} alt="Tripedia for all your travel planning needs" />
+      <img src={banner} alt="Tripedia for all your travel planning needs" className="banner" />
       <form className="create_account_form">
         <h2>Create Account</h2>
         <input

--- a/src/Components/CreateAccount/CreateAccount.scss
+++ b/src/Components/CreateAccount/CreateAccount.scss
@@ -32,3 +32,18 @@ h2,
   background-color: #010202;
   color: white;
 }
+
+.login_link {
+  text-align: center;
+  margin: 10px 0px 30px;
+  font-size: 1.5em;
+}
+
+.login_link:hover {
+  cursor: pointer;
+  color: #DE582A;
+}
+
+.login_link:active {
+  color: red;
+}

--- a/src/Components/CreateAccount/CreateAccount.scss
+++ b/src/Components/CreateAccount/CreateAccount.scss
@@ -21,7 +21,6 @@ h2,
 .confirm_password_input,
 .submit_button {
   @extend %form_style;
-
 }
 
 .submit_button:disabled {

--- a/src/Components/CreateAccount/CreateAccount.scss
+++ b/src/Components/CreateAccount/CreateAccount.scss
@@ -29,7 +29,7 @@ h2,
   color: white;
 }
 
-button .submit_button {
+.submit_button {
   @extend %form_style;
   background-color: #010202;
   color: white;

--- a/src/Components/CreateAccount/CreateAccount.scss
+++ b/src/Components/CreateAccount/CreateAccount.scss
@@ -5,6 +5,7 @@
   font-size: 1.5em;
   align-self: center;
   text-align: center;
+  border-radius: 8px;
 }
 
 .create_account_form {
@@ -20,6 +21,7 @@ h2,
 .confirm_password_input,
 .submit_button {
   @extend %form_style;
+
 }
 
 .submit_button:disabled {
@@ -27,7 +29,7 @@ h2,
   color: white;
 }
 
-.submit_button {
+button .submit_button {
   @extend %form_style;
   background-color: #010202;
   color: white;

--- a/src/Components/LoginForm/LoginForm.js
+++ b/src/Components/LoginForm/LoginForm.js
@@ -40,9 +40,11 @@ const LoginForm = () => {
           value={password}
           onChange={handleChange}
         ></input>
-        <button disabled={!isEnabled} className="login_button" type="submit">
-          Login
-        </button>
+        <NavLink to="/" className="button">
+          <button disabled={!isEnabled} className="login_button" type="submit">
+            Login
+          </button>
+        </NavLink>
         <NavLink to="/create_account">
           <p className="create_account_link">Create Account</p>
         </NavLink>

--- a/src/Components/LoginForm/LoginForm.js
+++ b/src/Components/LoginForm/LoginForm.js
@@ -16,7 +16,7 @@ const LoginForm = () => {
   };
 
   return (
-    <main className='blah'>
+    <main>
       <img
         className="banner"
         src={banner}

--- a/src/Components/LoginForm/LoginForm.js
+++ b/src/Components/LoginForm/LoginForm.js
@@ -16,14 +16,14 @@ const LoginForm = () => {
   };
 
   return (
-    <main>
+    <main className="form_body">
       <img
         className="banner"
         src={banner}
         alt="Tripedia for all your travel planning needs"
       />
       <form className="login_form">
-        <h2>Login Form</h2>
+        <h2 className="form_title">Login Form</h2>
         <input
           className="email_input"
           type="email"

--- a/src/Components/LoginForm/LoginForm.scss
+++ b/src/Components/LoginForm/LoginForm.scss
@@ -32,10 +32,14 @@ h2 {
   color: white;
 }
 
-button .login_button {
+.login_button {
   @extend %form_style;
   background-color: #010202;
   color: white;
+}
+
+.button {
+  text-align: center;
 }
 
 .banner {

--- a/src/Components/LoginForm/LoginForm.scss
+++ b/src/Components/LoginForm/LoginForm.scss
@@ -5,6 +5,7 @@
   font-size: 1.5em;
   align-self: center;
   text-align: center;
+  border-radius: 8px;
 }
 
 .login_form {
@@ -31,13 +32,13 @@ h2 {
   color: white;
 }
 
-.login_button {
+button .login_button {
   @extend %form_style;
   background-color: #010202;
   color: white;
 }
 
-img {
+.banner {
   width: 100%;
 }
 

--- a/src/Components/LoginForm/LoginForm.scss
+++ b/src/Components/LoginForm/LoginForm.scss
@@ -1,3 +1,14 @@
+.form_body {
+  padding: 40px 150px 0px;
+  background-color: whitesmoke;
+  height: 120vh;
+}
+
+.banner {
+  border-radius: 8px;
+  width: 100%;
+}
+
 %form_style {
   margin: 10px;
   width: 33%;
@@ -21,10 +32,11 @@ h2,
   @extend %form_style;
 }
 
-h2 {
-  margin-top: 20px;
-  font-size: 3em;
+.form_title {
+  margin: 25px;
+  font-size: 2.6em;
   text-align: center;
+  width: 40%;
 }
 
 .login_button:disabled {
@@ -40,10 +52,6 @@ h2 {
 
 .button {
   text-align: center;
-}
-
-.banner {
-  width: 100%;
 }
 
 .create_account_link {

--- a/src/Components/Navigation/Navigation.js
+++ b/src/Components/Navigation/Navigation.js
@@ -7,10 +7,14 @@ const Navigation = () => {
   return(
     <nav className='navigation__contianer'>
       <div className='logo-title__nav'>
-        <NavLink to='/'><img className='tripedia-logo__nav' src={Logo} alt='Tripedia Logo' /></NavLink>
+        <NavLink to='/'>
+          <img className='tripedia-logo__nav' src={Logo} alt='Tripedia Logo' />
+        </NavLink>
         <h1 className='tripedia-text__nav'>TRIPEDIA</h1>
       </div>
-      <p>LogOut</p>
+      <NavLink to='/login'>
+        <p>LogOut</p>
+      </NavLink>
     </nav>
   )
 }


### PR DESCRIPTION
#### What’s this PR do? Adds links from login page to the main page on login, from the create account page to the main page, and from the main page to the login page. It also adds minor styling for the login page and create account page.
#### Where should the reviewer start? Pull down branch, got to `localhost:3000/login`, to `localhost:3000/create_account`, and `localhost3000`.
#### How should this be manually tested?  Enter information into all the fields on both the login and the create account pages and when you click on the login or create account button, it should take you to the home page with the map and forms. The logout at the top right should take you back to the login form.
#### Any background context you want to provide? @CLLane  and I spoke about the styling. This is a minor attempt. @CLLane, I would like you to "fix" the styling. I am passing the baton on this one.


#### What are the relevant tickets? #38
#### Screenshots (if appropriate) <img width="1421" alt="Screen Shot 2019-10-24 at 5 57 04 PM" src="https://user-images.githubusercontent.com/46384968/67533598-dbca5900-f687-11e9-9a7a-720fa5de8076.png">
<img width="1041" alt="Screen Shot 2019-10-24 at 5 57 43 PM" src="https://user-images.githubusercontent.com/46384968/67533617-eedd2900-f687-11e9-9281-e380a4573a7e.png">
#### Questions:
# Implements/Fixes:
* What issue does this close? #38
