### PR TITLE
Heroku deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "tripedia-fe",
   "version": "0.1.0",
+  "engines": {
+    "node": "12.6.0"
+  },
   "private": true,
   "dependencies": {
     "google-map-react": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "tripedia-fe",
   "version": "0.1.0",
-  "engines": {
-    "node": "12.6.0"
-  },
   "private": true,
+  "engines": {
+    "node": "12.12.0",
+    "npm": "6.11.3"
+  },
   "dependencies": {
-    "google-map-react": "^1.1.5",
+    "google-map-react": "^1.1.5", 
     "node-sass": "^4.12.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",

--- a/src/Components/CreateAccount/CreateAccount.js
+++ b/src/Components/CreateAccount/CreateAccount.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import './CreateAccount.scss';
-import banner from '../../images/banner.jpg'
+import banner from '../../Images/banner.jpg'
 
 
 const CreateAccount = () => {

--- a/src/Components/LoginForm/LoginForm.js
+++ b/src/Components/LoginForm/LoginForm.js
@@ -1,7 +1,8 @@
 import React, { useState, useContext } from "react";
 import "./LoginForm.scss";
 import { NavLink } from "react-router-dom";
-import banner from "../../images/banner.jpg";
+import banner from "../../Images/banner.jpg";
+
 
 const LoginForm = () => {
   const [loginState, handleForm] = useState({

--- a/src/Components/Navigation/Navigation.js
+++ b/src/Components/Navigation/Navigation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import './Navigation.scss';
-import Logo from '../../images/Logo1.png';
+// import Logo from '../../images/Logo1.png';
 import { NavLink } from 'react-router-dom';
 
 const Navigation = () => {
@@ -8,7 +8,7 @@ const Navigation = () => {
     <nav className='navigation__contianer'>
       <div className='logo-title__nav'>
         <NavLink to='/'>
-          <img className='tripedia-logo__nav' src={Logo} alt='Tripedia Logo' />
+          <img className='tripedia-logo__nav' src='' alt='Tripedia Logo' />
         </NavLink>
         <h1 className='tripedia-text__nav'>TRIPEDIA</h1>
       </div>

--- a/src/Components/Navigation/Navigation.js
+++ b/src/Components/Navigation/Navigation.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import './Navigation.scss';
-// import Logo from '../../images/Logo1.png';
+import Logo from '../../Images/Logo1.png';
 import { NavLink } from 'react-router-dom';
+
 
 const Navigation = () => {
   return(
     <nav className='navigation__contianer'>
       <div className='logo-title__nav'>
         <NavLink to='/'>
-          <img className='tripedia-logo__nav' src='' alt='Tripedia Logo' />
+          <img className='tripedia-logo__nav' src={Logo} alt='Tripedia Logo' />
         </NavLink>
         <h1 className='tripedia-text__nav'>TRIPEDIA</h1>
       </div>

--- a/src/Components/Pin/Pin.js
+++ b/src/Components/Pin/Pin.js
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
 import "./Pin.scss";
-import accommidationPin from "../../images/accommidation-pin.svg";
-import foodPin from "../../images/food-pin.svg";
-import mapPin from "../../images/map-pin.svg";
-import drinkPin from '../../images/drink-pin.svg';
+import accommidationPin from "../../Images/accommidation-pin.svg";
+import foodPin from "../../Images/food-pin.svg";
+import mapPin from "../../Images/map-pin.svg";
+import drinkPin from '../../Images/drink-pin.svg';
+
 
 
 const Pin = (props) => {


### PR DESCRIPTION
#### What’s this PR do?

Troubleshoots deploying to Heroku build failures, renames 'images' directory to 'Images' and updates relative imports to allow for asset location.

#### Where should the reviewer start?

Any file with images (login forms, Pin) have updated file paths. 

#### How should this be manually tested?

You should be able to go to https://tripedia-fe.herokuapp.com/ and see the app (apiKey currently not available until we fetch it from backend) 

#### Any background context you want to provide?

For some reason pushing to master with 'images' directory was being overwritten to 'Images' and subsequent builds were unable to locate resources. Not entirely sure why, but simplest fix seemed to be to update locally, which worked. 

#### What are the relevant tickets?

#48 

#### Screenshots (if appropriate)
#### Questions:
# Implements/Fixes:
* What issue does this close?
