### PR TITLE
Combine context providers

### DIFF
--- a/src/Components/AccommodationsForm/AccommodationsForm.js
+++ b/src/Components/AccommodationsForm/AccommodationsForm.js
@@ -4,16 +4,10 @@ import { FormContext } from "../../Contexts/FormContext";
 import accommodationSvg from "../../Images/accommodation-pin.svg";
 import { createStateObject, createCheckBoxNames } from "../../util/dataCleaner";
 
-const AccommodationsForm = ({
-  collapseForm,
-  openForm,
-  defaultForm,
-  formObject
-}) => {
+const AccommodationsForm = ({ collapseForm, openForm, defaultForm, formObject }) => {
   const { formState, setFormState } = useContext(FormContext);
   const stateObject = createStateObject(formObject);
   const checkboxNames = createCheckBoxNames(formObject);
-
   const [form, toggleClicked] = useState({ ...stateObject });
 
   const handleCheckBox = e => {
@@ -26,8 +20,8 @@ const AccommodationsForm = ({
         selectedCategories: formState.selectedCategories.concat(checkedArray)
       });
     } else {
-      const filteredState = formState.selectedCategories.length
-        ? formState.selectedCategories.filter(
+      const filteredState = formState.selectedCategories.length?
+        formState.selectedCategories.filter(
             object => object.category !== formattedName
           )
         : [];

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -12,22 +12,15 @@ import trees from "../../Images/trees.svg";
 import house from "../../Images/house.svg";
 import hotel from "../../Images/hotel.svg";
 import city from "../../Images/city.svg";
-import { LoadingContext } from "../../Contexts/LoadingContext";
 import { FormContext } from "../../Contexts/FormContext";
-import { UserContext } from "../../Contexts/UserContext";
 import { triviaFacts } from "../../util/trivia-facts";
 
 export const App = () => {
-  const [isLoadingState, setLoadingContext] = useState({ isLoading: false, loadingArray: [] });
-  const loadingState = useMemo(() => ({ isLoadingState, setLoadingContext }), [
-    isLoadingState,
-    setLoadingContext
-  ]);
   const [formState, setFormState] = useState({
-    origin: "",
-    originCity: "",
-    destination: "",
-    destinationCity: "",
+    origin: '',
+    originCity: '',
+    destination: '',
+    destinationCity: '',
     tripSubmitted: false,
     attractions: {},
     accommodations: {},
@@ -36,16 +29,18 @@ export const App = () => {
     services: {},
     miscellaneous: {},
     selectedCategories: [],
-    trip_id: "",
-    waypoints: []
+    trip_id: '',
+    waypoints: [],
+    isLoading: false,
+    loadingArray: [],
+    email: '',
+    name: '',
+    id: '',
+    distance: ''
   });
-
   const currentForm = useMemo(() => ({ formState, setFormState }), [formState, setFormState]);
-  const [user, userLogin] = useState({ email: '', name: '', id: ''});
-  const loggedInUser = useMemo(() => ({ user, userLogin }), [ user, userLogin ]);
-  const {isLoading} = isLoadingState;
+  const { isLoading } = formState;
 
-  
   const selectTriviaFact = triviaArray => {
     let index = Math.floor(Math.random() * triviaArray.length);
     return triviaArray[index];
@@ -54,94 +49,86 @@ export const App = () => {
   if (!isLoading) {
     return (
       <FormContext.Provider value={currentForm}>
-        <UserContext.Provider value={loggedInUser}>
-          <LoadingContext.Provider value={loadingState}>
-            <div>
-              <Route exact path="/" render={() => <LoginForm />} />
-              <Route
-                exact
-                path="/create_account"
-                render={() => <CreateAccount />}
-              />
-              <Route
-                exact
-                path="/map"
-                render={() => (
-                  <div className="nav_banner">
-                    <Navigation />
-                    <div className="map-form__container">
-                      <FormsContainer />
-                      <div className="map-container">
-                        <Map
-                        />
-                      </div>
-                    </div>
+        <div>
+          <Route exact path="/" render={() => <LoginForm />} />
+          <Route
+            exact
+            path="/create_account"
+            render={() => <CreateAccount />}
+          />
+          <Route
+            exact
+            path="/map"
+            render={() => (
+              <div className="nav_banner">
+                <Navigation />
+                <div className="map-form__container">
+                  <FormsContainer />
+                  <div className="map-container">
+                    <Map
+                    />
                   </div>
-                )}
-              />
-            </div>
-          </LoadingContext.Provider>
-        </UserContext.Provider>
+                </div>
+              </div>
+            )}
+          />
+        </div>
       </FormContext.Provider>
     );
   } else {
     return (
       <FormContext.Provider value={currentForm}>
-        <UserContext.Provider value={loggedInUser}>
-          <LoadingContext.Provider value={loadingState}>
-            <div>
-              <Route exact path="/" render={() => <LoginForm />} />
-              <Route
-                exact
-                path="/create_account"
-                render={() => <CreateAccount />}
-              />
-              <Route
-                exact
-                path="/map"
-                render={() => (
-                  <div className="nav_banner">
-                    <Navigation />
-                    <div className="map-form__container">
-                      <FormsContainer />
-                      <div className="map-container">
-                        <Map />
-                      </div>
-                    </div>
+        <div>
+          <Route exact path="/" render={() => <LoginForm />} />
+          <Route
+            exact
+            path="/create_account"
+            render={() => <CreateAccount />}
+          />
+          <Route
+            exact
+            path="/map"
+            render={() => (
+              <div className="nav_banner">
+                <Navigation />
+                <div className="map-form__container">
+                  <FormsContainer />
+                  <div className="map-container">
+                    <Map />
                   </div>
-                )}
-              />
-            </div>
-            <div className="app-is-loading">
-              <div className="trivia-box__container">
-                <p className="did-you-know__text">
-                  Did you know?
-                </p>
-                <p>{selectTriviaFact(triviaFacts)}</p>
-                <div className="animation-container">
-                  <img
-                    className="loading__icon"
-                    alt="loading"
-                    src={LoadingIcon}
-                  ></img>
-                  <img className="stop-sign" alt="loading" src={stopSign}></img>
-                  <img className="house" alt="loading" src={house}></img>
-                  <img className="trees" alt="loading" src={trees}></img>
-                  <img className="trees" alt="loading" src={trees}></img>
-                  <img className="trees" alt="loading" src={trees}></img>
-                  <img className="trees" alt="loading" src={trees}></img>
-                  <img className="trees" alt="loading" src={trees}></img>
-                  <img className="city" alt="loading" src={city}></img>
-                  <img className="city" alt="loading" src={city}></img>
-                  <img className="city2" alt="loading" src={city}></img>
-                  <img className="city2" alt="loading" src={city}></img>
-                  <img className="hotel" alt="loading" src={hotel}></img>
-                  <div className="road"></div>
                 </div>
               </div>
+            )}
+          />
+        </div>
+        <div className="app-is-loading">
+          <div className="trivia-box__container">
+            <p className="did-you-know__text">
+              Did you know?
+            </p>
+            <p>{selectTriviaFact(triviaFacts)}</p>
+            <div className="animation-container">
+              <img
+                className="loading__icon"
+                alt="loading"
+                src={LoadingIcon}
+              ></img>
+              <img className="stop-sign" alt="loading" src={stopSign}></img>
+              <img className="house" alt="loading" src={house}></img>
+              <img className="trees" alt="loading" src={trees}></img>
+              <img className="trees" alt="loading" src={trees}></img>
+              <img className="trees" alt="loading" src={trees}></img>
+              <img className="trees" alt="loading" src={trees}></img>
+              <img className="trees" alt="loading" src={trees}></img>
+              <img className="city" alt="loading" src={city}></img>
+              <img className="city" alt="loading" src={city}></img>
+              <img className="city2" alt="loading" src={city}></img>
+              <img className="city2" alt="loading" src={city}></img>
+              <img className="hotel" alt="loading" src={hotel}></img>
+              <div className="road"></div>
             </div>
-          </LoadingContext.Provider>
-        </UserContext.Provider>
+          </div>
+        </div>
       </FormContext.Provider>
     );
   }

--- a/src/Components/App/__snapshots__/App.test.js.snap
+++ b/src/Components/App/__snapshots__/App.test.js.snap
@@ -9,9 +9,15 @@ exports[`App should match the wrapper with data passed in 1`] = `
         "attractions": Object {},
         "destination": "",
         "destinationCity": "",
+        "distance": "",
         "drinks": Object {},
+        "email": "",
         "food": Object {},
+        "id": "",
+        "isLoading": false,
+        "loadingArray": Array [],
         "miscellaneous": Object {},
+        "name": "",
         "origin": "",
         "originCity": "",
         "selectedCategories": Array [],
@@ -24,47 +30,22 @@ exports[`App should match the wrapper with data passed in 1`] = `
     }
   }
 >
-  <ContextProvider
-    value={
-      Object {
-        "user": Object {
-          "email": "",
-          "id": "",
-          "name": "",
-        },
-        "userLogin": [Function],
-      }
-    }
-  >
-    <ContextProvider
-      value={
-        Object {
-          "isLoadingState": Object {
-            "isLoading": false,
-            "loadingArray": Array [],
-          },
-          "setLoadingContext": [Function],
-        }
-      }
-    >
-      <div>
-        <Route
-          exact={true}
-          path="/"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          path="/create_account"
-          render={[Function]}
-        />
-        <Route
-          exact={true}
-          path="/map"
-          render={[Function]}
-        />
-      </div>
-    </ContextProvider>
-  </ContextProvider>
+  <div>
+    <Route
+      exact={true}
+      path="/"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
+      path="/create_account"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
+      path="/map"
+      render={[Function]}
+    />
+  </div>
 </ContextProvider>
 `;

--- a/src/Components/AttractionsForm/AttractionsForm.js
+++ b/src/Components/AttractionsForm/AttractionsForm.js
@@ -4,14 +4,8 @@ import { FormContext } from "../../Contexts/FormContext";
 import attractionSvg from "../../Images/attractions-pin.svg";
 import { createStateObject, createCheckBoxNames } from "../../util/dataCleaner";
 
-const AttractionsForm = ({
-  collapseForm,
-  openForm,
-  defaultForm,
-  formObject
-}) => {
+const AttractionsForm = ({ collapseForm, openForm, defaultForm, formObject}) => {
   const { formState, setFormState } = useContext(FormContext);
-
   const stateObject = createStateObject(formObject);
   const checkboxNames = createCheckBoxNames(formObject);
   const [form, toggleClicked] = useState({ ...stateObject });

--- a/src/Components/CreateAccount/CreateAccount.js
+++ b/src/Components/CreateAccount/CreateAccount.js
@@ -2,30 +2,29 @@ import React, { useState, useContext } from 'react';
 import { NavLink } from 'react-router-dom';
 import './CreateAccount.scss';
 import banner from '../../Images/banner.png';
-import { UserContext } from '../../Contexts/UserContext';
+import { FormContext } from '../../Contexts/FormContext';
 import { createAccount } from '../../util/apiCalls';
 
 const CreateAccount = () => {
-  const { userLogin } = useContext(UserContext);
-  
+  const { formState, setFormState } = useContext(FormContext);
   const [accountState, setAccountState] = useState({
     name: '',
     email: '',
     password: '',
     password_confirmation: '',
   })
-
   const {name, email, password, password_confirmation} = accountState
   const isEnabled = email && password && name && password && password_confirmation;
   
- const handleChange = (e) => {
+  const handleChange = (e) => {
    setAccountState({...accountState, [e.target.name]: e.target.value })
   }
 
   const handleSubmit = async () => {
     try {
       const userInfo = await createAccount(name, email, password, password_confirmation);
-      userLogin({ 
+      setFormState({
+        ...formState,
         name: userInfo.name,
         email: userInfo.email,
         id: userInfo.id

--- a/src/Components/DrinksForm/DrinksForm.js
+++ b/src/Components/DrinksForm/DrinksForm.js
@@ -6,10 +6,8 @@ import { createStateObject, createCheckBoxNames } from "../../util/dataCleaner";
 
 const DrinksForm = ({ collapseForm, openForm, defaultForm, formObject }) => {
   const { formState, setFormState } = useContext(FormContext);
-
   const stateObject = createStateObject(formObject);
   const checkboxNames = createCheckBoxNames(formObject);
-
   const [form, toggleClicked] = useState({ ...stateObject });
 
   const handleCheckBox = e => {
@@ -67,7 +65,7 @@ const DrinksForm = ({ collapseForm, openForm, defaultForm, formObject }) => {
         }
       >
         <img alt="drinks" src={drinkSvg}></img>
-        <p>- DrinkForm -</p>
+        <p>- Drinks -</p>
       </div>
     );
   }

--- a/src/Components/DrinksForm/__snapshots__/DrinksForm.test.js.snap
+++ b/src/Components/DrinksForm/__snapshots__/DrinksForm.test.js.snap
@@ -32,7 +32,7 @@ exports[`DrinksForm should mock formContext and match a snapshot 1`] = `
       src="drink-pin.svg"
     />
     <p>
-      - DrinkForm -
+      - Drinks -
     </p>
   </div>
 </DrinksForm>

--- a/src/Components/FoodForm/FoodForm.js
+++ b/src/Components/FoodForm/FoodForm.js
@@ -6,10 +6,8 @@ import { createStateObject, createCheckBoxNames } from "../../util/dataCleaner";
 
 const FoodForm = ({ collapseForm, openForm, defaultForm, formObject }) => {
   const { formState, setFormState } = useContext(FormContext);
-
   const stateObject = createStateObject(formObject);
   const checkboxNames = createCheckBoxNames(formObject);
-
   const [form, toggleClicked] = useState({ ...stateObject });
 
   const handleCheckBox = e => {

--- a/src/Components/FormsContainer/FormsContainer.js
+++ b/src/Components/FormsContainer/FormsContainer.js
@@ -12,7 +12,6 @@ import { FormContext } from '../../Contexts/FormContext';
 export const FormsContainer = () => {
   const { formState } = useContext(FormContext);
   const [collapsed, collapseFormContainer] = useState(false);
-
   const [openForm, collapseForm] = useState({
     StartForm: true,
     AttractionsForm: false,
@@ -22,7 +21,6 @@ export const FormsContainer = () => {
     ServicesForm: false,
     SubmitTripForm: false
   });
-
   const defaultOpenForm = {
     StartForm: false,
     AttractionsForm: false,
@@ -32,7 +30,6 @@ export const FormsContainer = () => {
     ServicesForm: false,
     SubmitTripForm: false
   };
-
   const { accommodations, attractions, food, drinks, services} = formState; 
 
   if (collapsed) {

--- a/src/Components/LoginForm/LoginForm.js
+++ b/src/Components/LoginForm/LoginForm.js
@@ -2,17 +2,18 @@ import React, { useState, useContext } from "react";
 import "./LoginForm.scss";
 import { NavLink } from "react-router-dom";
 import banner from "../../Images/banner.png";
-import { UserContext } from '../../Contexts/UserContext';
+import { FormContext } from '../../Contexts/FormContext';
 import { loginUser } from '../../util/apiCalls';
 
 const LoginForm = () => {
-  const { userLogin } = useContext(UserContext);
+  const { formState, setFormState } = useContext(FormContext);
   const [loginState, handleForm] = useState({
     email: "",
     password: ""
   });
   const { email, password } = loginState;
   const isEnabled = email && password;
+  
   const handleChange = e => {
     handleForm({ ...loginState, [e.target.name]: e.target.value });
   };
@@ -20,7 +21,8 @@ const LoginForm = () => {
   const handleSubmit = async () => {
     try {
       const userInfo = await loginUser(email, password);
-      userLogin({
+      setFormState({
+        ...formState,
         email: userInfo.email,
         name: userInfo.name,
         id: userInfo.id

--- a/src/Components/Map/Map.js
+++ b/src/Components/Map/Map.js
@@ -32,7 +32,7 @@ import { getApiKey } from '../../util/apiCalls';
     };
     let directionsRenderer = new maps.DirectionsRenderer({
       path: { start, end },
-      draggable: true,
+      draggable: false,
       suppressMarkers: true
     });
     let directionsService = new maps.DirectionsService();

--- a/src/Components/Map/Map.js
+++ b/src/Components/Map/Map.js
@@ -3,20 +3,18 @@ import GoogleMapReact from 'google-map-react';
 import Pin from '../Pin/Pin';
 import './Map.scss'; 
 import { FormContext } from '../../Contexts/FormContext';
-import { LoadingContext } from "../../Contexts/LoadingContext";
 import { getApiKey } from '../../util/apiCalls';
 
   const Map = () => {
   const { formState } = useContext(FormContext);
-  const { isLoadingState } = useContext(LoadingContext);
-  const { loadingArray } = isLoadingState;
+  const { selectedCategories, loadingArray } = formState;
   const [ keyString, updateKeyString ] = useState('')
   const [stops, updateStops] = useState([]);
   const waypoints = stops.map(stop => ({
     location : {
       lat: stop.latitude,
       lng: stop.longitude
-    },
+      },
     stopover: true
   }));
 
@@ -62,8 +60,6 @@ import { getApiKey } from '../../util/apiCalls';
       />
     );
   };
-
-  const { selectedCategories } = formState; 
 
   const stopList = stops.map((stop, i) => createPin(stop, i));
   const pinList = selectedCategories.map((obj, i) => createPin(obj, i));

--- a/src/Components/Pin/Pin.js
+++ b/src/Components/Pin/Pin.js
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from "react";
 import "./Pin.scss";
-import accommidationPin from "../../Images/accommodation-pin.svg";
+import accommodationPin from "../../Images/accommodation-pin.svg";
 import foodPin from "../../Images/food-pin.svg";
 import mapPin from "../../Images/map-pin.svg";
 import drinkPin from "../../Images/drink-pin.svg";
@@ -48,7 +48,7 @@ const Pin = (props) => {
   const switchImage = imageType => {
     switch (imageType) {
       case "accommodations":
-        return accommidationPin;
+        return accommodationPin;
       case "food":
         return foodPin;
       case "drinks":

--- a/src/Components/ServicesForm/ServicesForm.js
+++ b/src/Components/ServicesForm/ServicesForm.js
@@ -6,10 +6,8 @@ import { createStateObject, createCheckBoxNames } from "../../util/dataCleaner";
 
 const ServicesForm = ({ collapseForm, openForm, defaultForm, formObject }) => {
   const { formState, setFormState } = useContext(FormContext);
-
   const stateObject = createStateObject(formObject);
   const checkboxNames = createCheckBoxNames(formObject);
-
   const [form, toggleClicked] = useState({ ...stateObject });
 
   const handleCheckBox = e => {
@@ -67,7 +65,7 @@ const ServicesForm = ({ collapseForm, openForm, defaultForm, formObject }) => {
         }
       >
         <img alt="services" src={serviceSvg}></img>
-        <p>- ServicesForm -</p>
+        <p>- Services -</p>
       </div>
     );
   }

--- a/src/Components/ServicesForm/__snapshots__/ServicesForm.test.js.snap
+++ b/src/Components/ServicesForm/__snapshots__/ServicesForm.test.js.snap
@@ -32,7 +32,7 @@ exports[`ServicesForm should mock formContext and match a snapshot 1`] = `
       src="services-pin.svg"
     />
     <p>
-      - ServicesForm -
+      - Services -
     </p>
   </div>
 </ServicesForm>

--- a/src/Components/SubmitTripForm/SubmitTripForm.js
+++ b/src/Components/SubmitTripForm/SubmitTripForm.js
@@ -1,25 +1,26 @@
 import React, { useContext } from "react";
 import "./SubmitTripForm.scss";
 import { FormContext } from "../../Contexts/FormContext";
-import { UserContext } from "../../Contexts/UserContext";
-import { LoadingContext } from "../../Contexts/LoadingContext";
 import { submitTrip } from "../../util/apiCalls";
 import submitSvg from '../../Images/end.svg';
 
 const SubmitTripForm = ({ collapseForm, openForm, defaultForm }) => {
-  const { formState } = useContext(FormContext);
-  const { user } = useContext(UserContext);
-  const { setLoadingContext } = useContext(LoadingContext);
-  const { originCity, destinationCity, trip_id, waypoints } = formState;
-  const { id } = user;
+  const { formState, setFormState } = useContext(FormContext);
+  const { originCity, destinationCity, trip_id, waypoints, id } = formState;
 
   const handleSubmit = async e => {
     e.preventDefault();
     try {
-    setLoadingContext({ isLoading: true, loadingArray: [true] });
+    setFormState({
+      ...formState, 
+      isLoading: true, 
+      loadingArray: [true] });
     await submitTrip(id, trip_id, originCity, destinationCity, waypoints);
     let timeout = setTimeout(() => {
-      setLoadingContext({ isLoading: false, loadingArray: [false] });
+      setFormState({
+        ...formState, 
+        isLoading: false, 
+        loadingArray: [false] });
       clearTimeout(timeout);
     }, 12500);
     } catch ({message}) {

--- a/src/Contexts/LoadingContext.js
+++ b/src/Contexts/LoadingContext.js
@@ -1,3 +1,0 @@
-import { createContext } from "react";
-
-export const LoadingContext = createContext({});

--- a/src/Contexts/UserContext.js
+++ b/src/Contexts/UserContext.js
@@ -1,3 +1,0 @@
-import { createContext } from "react";
-
-export const UserContext = createContext({});

--- a/src/util/dataCleaner.js
+++ b/src/util/dataCleaner.js
@@ -11,213 +11,29 @@ export const assignObjectToArrays = (array) => {
   const drinks = [];
   const services = [];
   const miscellaneous = [];
+  const accommodationTypes = ['hotels', 'hotels & travel', 'bed & breakfast', 'guest houses', 'resorts', 'rv parks'];
+  const attractionTypes = ['art museums', 'hiking', 'day spas', 'escape games', 'haunted houses', 'parks', 'landmarks & historical buildings', 'art galleries', 'walking tours', 'arts & entertainment', 'day camps', 'boat tours', 'boating', 'tours', 'bowling', 'climbing', 'historical tours', 'art classes', 'arcades', 'bubble soccer', 'gay bars', 'jazz & blues', 'performing arts'];
+  const foodTypes = ['gastropubs', 'sandwiches', 'steakhouses', 'fast food', 'chocolatiers & shops', 'cantonese', 'sushi bars', 'asian fusion', 'diners', 'american (traditional)', 'american (new)','chinese', 'mexican', 'pizza', 'burgers', 'coffee & tea', 'bakeries','breakfast & brunch', 'japanese'];
+  const drinkTypes = ['bars', 'wine bars', 'wine tasting room', 'beer, wine & spirits', 'lounges', 'dive bars', 'distilleries', 'breweries',
+  'beer bars'];
+  const serviceTypes = ['gyms', 'outdoor gear', 'gift shops', 'hunting & fishing supplies', 'body shops', 'medical centers', 'veterinarians', 'waxing', 'grocery'];
 
   array.forEach(obj => {
     const type = obj.category;
-    switch (type) {
-      case 'hotels':
-        accommodations.push({...obj, svg: 'accommodations' });
-        return
-      case 'hotels & travel':
-        accommodations.push({ ...obj, svg: 'accommodations' })
-        return
-      case 'bed & breakfast':
-        accommodations.push({ ...obj, svg: 'accommodations' });
-        return
-      case 'guest houses':
-        accommodations.push({ ...obj, svg: 'accommodations' });
-        return
-      case 'resorts':
-        accommodations.push({ ...obj, svg: 'accommodations' });
-        return
-      case 'rv parks':
-        accommodations.push({ ...obj, svg: 'accommodations' });
-        return
-      case 'art museums':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'hiking':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'day spas':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'escape games':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'haunted houses':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'parks' :
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'landmarks & historical buildings':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'art galleries':
-        attractions.push({ ...obj, svg: 'attractions' });  
-        return   
-      case 'walking tours':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'arts & entertainment':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'day camps':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'boat tours':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'boating' :
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'tours':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'bowling':
-        attractions.push({ ...obj, svg: 'attractions' })
-        return
-      case 'climbing':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'historical tours':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'art classes':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'arcades' :
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'bubble soccer':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'gay bars':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'jazz & blues':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'performing arts':
-        attractions.push({ ...obj, svg: 'attractions' });
-        return
-      case 'gastropubs':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'sandwiches':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'steakhouses':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'fast food' :
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'chocolatiers & shops':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'cantonese' :
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'sushi bars':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'asian fusion':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'diners':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'american (traditional)':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'american (new)':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'chinese' :
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'mexican':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'pizza':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'burgers':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'coffee & tea':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'bakeries':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'breakfast & brunch':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'japanese':
-        food.push({ ...obj, svg: 'food' });
-        return
-      case 'bars':
-        drinks.push({ ...obj, svg: 'drinks' });
-        return
-      case 'wine bars':
-        drinks.push({ ...obj, svg: 'drinks' });
-        return
-      case 'wine tasting room':
-        drinks.push({ ...obj, svg: 'drinks' });
-        return
-      case 'beer, wine & spirits':
-        drinks.push({ ...obj, svg: 'drinks' });
-        return
-      case 'lounges':
-        drinks.push({ ...obj, svg: 'drinks' });
-        return
-      case 'dive bars':
-        drinks.push({ ...obj, svg: 'drinks' });
-        return
-      case 'distilleries':
-        drinks.push({ ...obj, svg: 'drinks' });
-        return
-      case 'breweries':
-        drinks.push({ ...obj, svg: 'drinks' });
-        return
-      case 'beer bars':
-        drinks.push({ ...obj, svg: 'drinks' });
-        return
-      case 'gyms':
-        services.push({ ...obj, svg: 'services' });
-        return
-      case 'outdoor gear':
-        services.push({ ...obj, svg: 'services' });
-        return
-      case 'gift shops':
-        services.push({ ...obj, svg: 'services' });
-        return
-      case 'hunting & fishing supplies':
-        services.push({ ...obj, svg: 'services' });
-        return
-      case 'body shops':
-        services.push({ ...obj, svg: 'services' });
-        return
-      case 'medical centers':
-        services.push({ ...obj, svg: 'services' });
-        return
-      case 'veterinarians':
-        services.push({ ...obj, svg: 'services' });
-        return
-      case 'waxing':
-        services.push({ ...obj, svg: 'services' });
-        return
-      case 'grocery':
-        services.push({ ...obj, svg: 'services' });
-        return
-      default:
-        miscellaneous.push(obj);
-        return
+    if (accommodationTypes.includes(type)) {
+      accommodations.push({ ...obj, svg: 'accommodations' });
+    } else if (attractionTypes.includes(type)) {
+      attractions.push({ ...obj, svg: 'attractions' });
+    } else if (foodTypes.includes(type)) {
+      food.push({ ...obj, svg: 'food' });
+    } else if (drinkTypes.includes(type)) {
+      drinks.push({ ...obj, svg: 'drinks' });
+    } else if (serviceTypes.includes(type)) {
+      services.push({ ...obj, svg: 'services' });
+    } else {
+      miscellaneous.push(obj)
     }
-  })
+  }); 
  
   const arrays = [accommodations, attractions, food, drinks, services, miscellaneous];
   return arrays


### PR DESCRIPTION
#### What’s this PR do?
Combines separate context objects into single one, including loading boolean and array and user name, id, and email into central formState. Updates all interactions with previous context objects to setFormState, and adjusts the flow of information coming from initial response to include distance of trip. Switch statement in data cleaner has now been refactored into if/else with five arrays of all categories. 

#### Where should the reviewer start?

Changes have been made to all forms, App, Map and Pin components as necessary, and to dataCleaner.js. 

#### How should this be manually tested?

Previous flow of information should now be unified in FormContext, after submitting origin and destinations for a trip information should also include total distance. Categories in trip should all be present in forms and able to be toggled. 

#### Any background context you want to provide?
#### What are the relevant tickets?

See below. 

#### Screenshots (if appropriate)
#### Questions:
# Implements/Fixes:
* What issue does this close?

Closes #68 on Tripedia backend project board. 
